### PR TITLE
:bug: (DocumentParser) Change header separator from "**/" into "*/"

### DIFF
--- a/src/DocumentParser.ts
+++ b/src/DocumentParser.ts
@@ -30,7 +30,7 @@ export class DocumentParser {
     documentText: string,
   ): DesignDocumentFormatType => {
     // TODO: Use a cleaner way to ignore file body and keep header
-    const [header, body] = documentText.split('**/');
+    const [header, body] = documentText.split('*/');
     if (!body) {
       // the file actually has no header
       return {


### PR DESCRIPTION
VSCode automcompletes JSdoc annotation with a "*/" at the end. With this separator users can use this handy autocompletion along with
conceptor